### PR TITLE
Update hunts.md

### DIFF
--- a/docs/game_concept/hunts.md
+++ b/docs/game_concept/hunts.md
@@ -4,7 +4,7 @@
   <img width="128" src="./img/rudder.png">
 </p>
 
-Any player can start a hunt. However if a player starts a hunt without a pirate, he/she will not gt any reward when finding treasures.
+Any player can start a hunt. However if a player starts a hunt without a pirate, he/she will not get any reward when finding treasures.
 
 
 ```blockdiag


### PR DESCRIPTION
I noticed an oversight on the whitepaper on the Hunt page. The "e" was not included while attempting to spell "Get" hence I added it. Any player can start a hunt. However if a player starts a hunt without a pirate, he/she will not g"e"t any reward when finding treasures."